### PR TITLE
Fix building site locally tab shortcode error

### DIFF
--- a/content/web/_index.md
+++ b/content/web/_index.md
@@ -90,4 +90,6 @@ Please note that Snowflake, Databricks, or BigQuery will be used for illustratio
 
 !['logo-banner' ](images/databricks_dashboard.png)
 
+{{% /tab %}}
+
 {{< /tabs >}}


### PR DESCRIPTION
Add closing tab shortcode which was causing local builds to fail when running `./scripts/build.sh serve` with: 
```
Error: error building site: assemble: "/data-product-accelerators/build/content/web/_index.md:81:1": failed to extract shortcode: shortcode "tabs" must be closed or self-closed
```
The tabs on this page still function correctly on our deployed site, this is only a problem I encountered when developing locally!